### PR TITLE
Add screenshot via 's' key

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,3 +1,5 @@
+import FileSaver from 'file-saver';
+
 import AppUI from './AppUI.svelte';
 import { displayOptions } from './displayOptions';
 
@@ -122,6 +124,15 @@ function makeLayer(scene_obj) {
   });
 
   layer.addTo(map);
+
+  // setup screenshot event
+  document.addEventListener('keydown', ({ key }) => {
+    if (key == "s") { // take screenshot
+      layer.scene.screenshot().then(function (screenshot) {
+        FileSaver.saveAs(screenshot.blob, `invader-${(new URLSearchParams(appUI.get().queryParams))}.png`);
+      });
+    }
+  });
 
   window.layer = layer; // debugging
   window.scene = layer.scene;  // debugging

--- a/package-lock.json
+++ b/package-lock.json
@@ -512,6 +512,11 @@
         }
       }
     },
+    "file-saver": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/file-saver/-/file-saver-2.0.2.tgz",
+      "integrity": "sha512-Wz3c3XQ5xroCxd1G8b7yL0Ehkf0TC9oYC6buPFkNnU9EnaPlifeAFCyCh+iewXTyFRcg0a6j3J7FmJsIhlhBdw=="
+    },
     "fill-range": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "serve": "http-server -p 8001 --cors -c-1"
   },
   "dependencies": {
+    "file-saver": "^2.0.2",
     "http-server": "^0.11.1",
     "npm-run-all": "^4.1.5",
     "rollup": "^1.12.3",


### PR DESCRIPTION
Adds a screenshot, with the current query params in the file name.

Note this *doesn't* include the map location/zoom in the filename, which would be useful, but we would need to come up with a new syntax for it in the filename, since it includes characters (`/` and `.`) that don't mix well with filenames -- and thus also make the filename not a "copy-paste" operation to use as a URL query string if trying to re-construct the view that was used for the screenshot. So anyway we can revisit/add that.