### PR TITLE
Add scene export

### DIFF
--- a/AppUI.svelte
+++ b/AppUI.svelte
@@ -47,6 +47,7 @@
         {/if}
       <table>
           <tr>
+            <!-- Basemap selector -->
             <td>basemap:</td>
             <td>
               <select bind:value="basemap">
@@ -54,6 +55,10 @@
                   <option value="{basemap}">{basemap}</option>
                 {/each}
               </select>
+            </td>
+            <!-- Export scene -->
+            <td>
+              <button on:click="fire('exportScene')">export</button>
             </td>
           </tr>
       </table>

--- a/basemaps.js
+++ b/basemaps.js
@@ -28,6 +28,19 @@ export function getNextBasemap(basemap) {
   return names[0]; // otherwise just return first basemap
 }
 
+// add the base path of the current page to the URL
+function addBasePath(url) {
+  let base = window.location.origin + window.location.pathname;
+  if (base.slice(-1) !== '/') {
+    base += '/';
+  }
+  return base + url;
+}
+
+// skeletal structure of Invader viz scene, merged on top of underlying basemap, extended at run-time
+// based on current viz settings
+const xyzTangramBaseScene = addBasePath('tangram_xyz_scene.yaml');
+
 // this gets merged into basemaps to change 'mapzen' vector tile source definitions to their XYZ HERE equivalent
 // TODO: this does not yet override terrain/normal tiles for hillshading
 const xyzTilezenSourceOverride = {
@@ -67,7 +80,7 @@ export const basemaps = {
   'xyz-pixel': {
     import: [
       'https://raw.githubusercontent.com/sensescape/xyz-pixel/master/scene.yaml',
-      'tangram_xyz_scene.yaml'
+      xyzTangramBaseScene
     ],
     global: {
       featureLabelFont: labelFontPresets.light
@@ -81,7 +94,7 @@ export const basemaps = {
   'xyz-pixel-dark': {
     import: [
       'https://raw.githubusercontent.com/sensescape/xyz-pixel-dark/master/scene.yaml',
-      'tangram_xyz_scene.yaml'
+      xyzTangramBaseScene
     ],
     global: {
       featureLabelFont: labelFontPresets.dark
@@ -95,7 +108,7 @@ export const basemaps = {
   'xyz-pixel-pastel': {
     import: [
       'https://raw.githubusercontent.com/sensescape/xyz-pixel-pastel/master/scene.yaml',
-      'tangram_xyz_scene.yaml'
+      xyzTangramBaseScene
     ],
     global: {
       featureLabelFont: labelFontPresets.light
@@ -109,7 +122,7 @@ export const basemaps = {
   'xyz-dots': {
     import: [
       'https://raw.githubusercontent.com/sensescape/xyz-dots/master/scene.yaml',
-      'tangram_xyz_scene.yaml'
+      xyzTangramBaseScene
     ],
     global: {
       featureLabelFont: labelFontPresets.light
@@ -123,7 +136,7 @@ export const basemaps = {
   'xyz-dots-dark': {
     import: [
       'https://raw.githubusercontent.com/sensescape/xyz-dots-dark/master/scene.yaml',
-      'tangram_xyz_scene.yaml'
+      xyzTangramBaseScene
     ],
     global: {
       featureLabelFont: labelFontPresets.dark
@@ -137,7 +150,7 @@ export const basemaps = {
   'xyz-bw-texture': {
     import: [
       'https://raw.githubusercontent.com/sensescape/bw-texture/master/scene.yaml',
-      'tangram_xyz_scene.yaml'
+      xyzTangramBaseScene
     ],
     global: {
       featureLabelFont: labelFontPresets.light
@@ -151,7 +164,7 @@ export const basemaps = {
   'xyz-grid': {
     import: [
       'https://raw.githubusercontent.com/sensescape/xyz-grid/master/scene.yaml',
-      'tangram_xyz_scene.yaml'
+      xyzTangramBaseScene
     ],
     global: {
       featureLabelFont: labelFontPresets.light
@@ -165,7 +178,7 @@ export const basemaps = {
   'xyz-grid-dark': {
     import: [
       'https://raw.githubusercontent.com/sensescape/xyz-grid-dark/master/scene.yaml',
-      'tangram_xyz_scene.yaml'
+      xyzTangramBaseScene
     ],
     global: {
       featureLabelFont: labelFontPresets.dark
@@ -179,7 +192,7 @@ export const basemaps = {
   'xyz-grid-color': {
     import: [
       'https://raw.githubusercontent.com/sensescape/xyz-grid-color/master/scene.yaml',
-      'tangram_xyz_scene.yaml'
+      xyzTangramBaseScene
     ],
     global: {
       featureLabelFont: labelFontPresets.light
@@ -189,11 +202,11 @@ export const basemaps = {
       _xyz_dots: { draw: { points: { color: [0, 0, 1, 0.5] } } }
     },
     ...xyzTilezenSourceOverride
-  },  
+  },
   'xyz-elevation-dots': {
     import: [
       'https://raw.githubusercontent.com/sensescape/xyz-elevation-dots/master/scene.yaml',
-      'tangram_xyz_scene.yaml'
+      xyzTangramBaseScene
     ],
     global: {
       featureLabelFont: labelFontPresets.dark
@@ -203,11 +216,11 @@ export const basemaps = {
       _xyz_dots: { draw: { points: { color: [0, 0, 1, 0.5] } } }
     },
     ...xyzTilezenSourceOverride
-  },  
+  },
   'xyz-studio-spring-soft': {
     import: [
       'https://raw.githubusercontent.com/sensescape/xyz-studio-spring-soft/master/scene.yaml',
-      'tangram_xyz_scene.yaml'
+      xyzTangramBaseScene
     ],
     global: {
       featureLabelFont: labelFontPresets.light
@@ -221,7 +234,7 @@ export const basemaps = {
   'xyz-studio-spring-bright': {
     import: [
       'https://raw.githubusercontent.com/sensescape/xyz-studio-spring-bright/master/scene.yaml',
-      'tangram_xyz_scene.yaml'
+      xyzTangramBaseScene
     ],
     global: {
       featureLabelFont: labelFontPresets.light
@@ -235,7 +248,7 @@ export const basemaps = {
   'xyz-studio-miami-day': {
     import: [
       'https://raw.githubusercontent.com/sensescape/xyz-studio-miami-day/master/scene.yaml',
-      'tangram_xyz_scene.yaml'
+      xyzTangramBaseScene
     ],
     global: {
       featureLabelFont: labelFontPresets.light
@@ -249,7 +262,7 @@ export const basemaps = {
    'xyz-studio-light': {
     import: [
       'https://raw.githubusercontent.com/sensescape/xyz-studio-light/master/scene.yaml',
-      'tangram_xyz_scene.yaml'
+      xyzTangramBaseScene
     ],
     global: {
       featureLabelFont: labelFontPresets.light
@@ -259,11 +272,11 @@ export const basemaps = {
       _xyz_dots: { draw: { points: { color: [0, 0, 1, 0.5] } } }
     },
     ...xyzTilezenSourceOverride
-  }, 
+  },
     'xyz-studio-dark': {
     import: [
       'https://raw.githubusercontent.com/sensescape/xyz-studio-dark/master/scene.yaml',
-      'tangram_xyz_scene.yaml'
+      xyzTangramBaseScene
     ],
     global: {
       featureLabelFont: labelFontPresets.dark
@@ -273,15 +286,15 @@ export const basemaps = {
       _xyz_dots: { draw: { points: { color: [0, 0, 1, 0.5] } } }
     },
     ...xyzTilezenSourceOverride
-  },  
-  
+  },
+
   'mapzen-refill-dark': {
     import: [
       'https://www.nextzen.org/carto/refill-style/refill-style.zip',
       'https://www.nextzen.org/carto/refill-style/themes/color-gray-gold.zip',
       'https://www.nextzen.org/carto/refill-style/themes/label-4.zip',
       // 'https://www.nextzen.org/carto/refill-style/themes/terrain-shading-dark.zip',
-      'tangram_xyz_scene.yaml'
+      xyzTangramBaseScene
     ],
     global: {
       featureLabelFont: labelFontPresets.dark
@@ -297,7 +310,7 @@ export const basemaps = {
       'https://www.nextzen.org/carto/refill-style/refill-style.zip',
       'https://www.nextzen.org/carto/refill-style/themes/label-4.zip',
       'https://www.nextzen.org/carto/refill-style/themes/terrain-shading-dark.zip',
-      'tangram_xyz_scene.yaml'
+      xyzTangramBaseScene
     ],
     global: {
       featureLabelFont: labelFontPresets.light
@@ -307,7 +320,7 @@ export const basemaps = {
   'mapzen-walkabout': {
     import: [
       'https://www.nextzen.org/carto/walkabout-style/walkabout-style.zip',
-      'tangram_xyz_scene.yaml'
+      xyzTangramBaseScene
     ],
     global: {
       featureLabelFont: labelFontPresets.light
@@ -316,7 +329,7 @@ export const basemaps = {
   },
   'none': {
     import: [
-      'tangram_xyz_scene.yaml'
+      xyzTangramBaseScene
     ],
     global: {
       featureLabelFont: labelFontPresets.dark
@@ -330,8 +343,8 @@ export const basemaps = {
   'satellite': {
     import: [
       'https://www.nextzen.org/carto/refill-style/refill-style.zip',
-      'tangram_xyz_scene.yaml',
-      'satellite.yaml',
+      xyzTangramBaseScene,
+      addBasePath('satellite.yaml'),
     ],
     global: {
       featureLabelFont: labelFontPresets.dark

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,5 @@
+[[headers]]
+  # Define which paths this specific [[headers]] block will cover.
+  for = "/*"
+    [headers.values]
+    Access-Control-Allow-Origin = "*"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1427,6 +1427,11 @@
         "object-assign": "^4.0.1"
       }
     },
+    "lodash": {
+      "version": "4.17.15",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+    },
     "lodash.camelcase": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "file-saver": "^2.0.2",
     "http-server": "^0.11.1",
+    "js-yaml": "^3.13.1",
     "leaflet": "^1.5.1",
     "leaflet-hash": "^0.2.1",
     "lodash": "^4.17.15",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "http-server": "^0.11.1",
     "leaflet": "^1.5.1",
     "leaflet-hash": "^0.2.1",
+    "lodash": "^4.17.15",
     "npm-run-all": "^4.1.5",
     "rollup": "^1.12.3",
     "rollup-plugin-commonjs": "^10.0.0",

--- a/tangram_xyz_scene.yaml
+++ b/tangram_xyz_scene.yaml
@@ -16,7 +16,7 @@ global:
     # dyanmic feature coloring, using the currently defined "color mode"
     # the `colorState` global holds settings that may be relevant to each mode (e.g. min/max, palette, etc.)
     featureColorDynamic: |
-      function () {
+      function (feature, global) {
         try {
           if (global.colorFunctions[global.colorMode]) {
             if (global.colorFunctions[global.colorMode].useProperty) {
@@ -39,7 +39,7 @@ global:
 
     # simple color by feature color property, or fallback to geometry type
     featureColorDefault: |
-        function() {
+        function(feature, global, $geometry) {
             var color;
             if (feature.color) {
                 color = feature.color
@@ -132,7 +132,7 @@ layers:
                 interactive: true
                 collide: false
                 blend_order: 0 # put our points under the basemap labels
-                color: global.featureColorDefault
+                color: function(){ return global.featureColorDefault(feature, global, $geometry); }
                 size: 6px
                 outline: {}
                 text:
@@ -151,7 +151,7 @@ layers:
         draw:
             _lines:
                 interactive: true
-                color: global.featureColorDefault
+                color: function(){ return global.featureColorDefault(feature, global, $geometry); }
                 width: 4px
                 order: 2000
                 outline:
@@ -180,7 +180,7 @@ layers:
         draw:
             _polygons_inlay:
                 interactive: true
-                color: global.featureColorDefault
+                color: function(){ return global.featureColorDefault(feature, global, $geometry); }
                 width: 2px
                 order: 300
             text:

--- a/utils.js
+++ b/utils.js
@@ -38,3 +38,15 @@ export function parseNestedObject(obj, level = -1, prop = null, propStack = [], 
 export function lookupProperty(properties, propStack) {
   return propStack && propStack.reduce((obj, prop) => obj && obj[prop] !== undefined ? obj[prop] : null, properties);
 }
+
+// stringify an object with JSON.stringify, but include functions as strings
+export function stringifyWithFunctions (obj) {
+  if (typeof obj === 'function') {
+    return obj.toString();
+  }
+
+  return JSON.stringify(obj, function (k, v) {
+    // Convert functions to strings
+    return (typeof v === 'function') ? v.toString() : v;
+  });
+};

--- a/utils.js
+++ b/utils.js
@@ -25,8 +25,8 @@ export function parseNestedObject(obj, level = -1, prop = null, propStack = [], 
     if (prop) {
       rows.push({ level, obj, prop: formatPropStack(propStack), propStack }); // header row
     }
-    for (var prop in obj) {
-      parseNestedObject(obj[prop], level + 1, prop, [...propStack, prop], rows);
+    for (const p in obj) {
+      parseNestedObject(obj[p], level + 1, p, [...propStack, p], rows);
     }
   } else {
     rows.push({ level, obj, prop: formatPropStack(propStack), value: obj, propStack });


### PR DESCRIPTION
Adds a scene export function and button in UI.

This required changes to how Tangram scenes are constructed. Previously, the Invader viz-specific scene updates were always applied "on top of" a *loaded* scene, e.g. the remote basemap YAML and assets would already have been loaded and expanded at run-time (along with other "base" scene files like `tangram_xyz_scene.yaml`). Such scene configs are not suitable for export, because they may contain local paths that won't load properly from another origin, or (worse) will include blob URLs for assets that were extracted from zipped scene files (these assets are temporary by nature and could never be loaded in another browser context).

In order to enable Invader viz scenes to be applied on top of (merged into) the scene before any `import`'ed files, the scene construction code can no longer assume the scene config nested objects it needs to write to have been created yet. This is now done with lodash `_set`, which will created any deeply nested object paths as necessary; this means any future additions to scene settings need to use this pattern as well.

Other changes included appending the local host to relative URLs, and ensuring compiled JS functions are stringified back to their original source before export.
